### PR TITLE
Add scanner config for using the front camera

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -3,6 +3,7 @@ complexity:
     ignoreSingleWhenExpression: true
   LongParameterList:
     ignoreAnnotated: ['Parcelize']
+    constructorThreshold: 8
 
 exceptions:
   TooGenericExceptionCaught:

--- a/quickie/src/main/kotlin/io/github/g00fy2/quickie/QRScannerActivity.kt
+++ b/quickie/src/main/kotlin/io/github/g00fy2/quickie/QRScannerActivity.kt
@@ -37,6 +37,7 @@ internal class QRScannerActivity : AppCompatActivity() {
   private var barcodeFormats = intArrayOf(Barcode.FORMAT_QR_CODE)
   private var hapticFeedback = true
   private var showTorchToggle = false
+  private var useFrontCamera = false
   internal var errorDialog: Dialog? = null
     set(value) {
       field = value
@@ -106,7 +107,12 @@ internal class QRScannerActivity : AppCompatActivity() {
 
       cameraProvider.unbindAll()
       try {
-        val camera = cameraProvider.bindToLifecycle(this, CameraSelector.DEFAULT_BACK_CAMERA, preview, imageAnalysis)
+        val cameraSelector = if (useFrontCamera) {
+          CameraSelector.DEFAULT_FRONT_CAMERA
+        } else {
+          CameraSelector.DEFAULT_BACK_CAMERA
+        }
+        val camera = cameraProvider.bindToLifecycle(this, cameraSelector, preview, imageAnalysis)
         binding.overlayView.visibility = View.VISIBLE
         if (showTorchToggle && camera.cameraInfo.hasFlashUnit()) {
           binding.overlayView.setTorchVisibilityAndOnClick(true) { camera.cameraControl.enableTorch(it) }
@@ -165,6 +171,7 @@ internal class QRScannerActivity : AppCompatActivity() {
       binding.overlayView.setHorizontalFrameRatio(it.horizontalFrameRatio)
       hapticFeedback = it.hapticFeedback
       showTorchToggle = it.showTorchToggle
+      useFrontCamera = it.useFrontCamera
     }
   }
 

--- a/quickie/src/main/kotlin/io/github/g00fy2/quickie/config/ParcelableScannerConfig.kt
+++ b/quickie/src/main/kotlin/io/github/g00fy2/quickie/config/ParcelableScannerConfig.kt
@@ -11,4 +11,5 @@ internal class ParcelableScannerConfig(
   val hapticFeedback: Boolean,
   val showTorchToggle: Boolean,
   val horizontalFrameRatio: Float,
+  val useFrontCamera: Boolean,
 ) : Parcelable

--- a/quickie/src/main/kotlin/io/github/g00fy2/quickie/config/ScannerConfig.kt
+++ b/quickie/src/main/kotlin/io/github/g00fy2/quickie/config/ScannerConfig.kt
@@ -13,6 +13,7 @@ public class ScannerConfig internal constructor(
   internal val hapticFeedback: Boolean,
   internal val showTorchToggle: Boolean,
   internal val horizontalFrameRatio: Float,
+  internal val useFrontCamera: Boolean,
 ) {
 
   public class Builder {
@@ -22,6 +23,7 @@ public class ScannerConfig internal constructor(
     private var hapticSuccessFeedback: Boolean = true
     private var showTorchToggle: Boolean = false
     private var horizontalFrameRatio: Float = 1f
+    private var useFrontCamera: Boolean = false
 
     /**
      * Set a list of interested barcode formats. List must not be empty.
@@ -57,6 +59,11 @@ public class ScannerConfig internal constructor(
     public fun setShowTorchToggle(enable: Boolean): Builder = apply { showTorchToggle = enable }
 
     /**
+     * Use the front camera.
+     */
+    public fun setUseFrontCamera(enable: Boolean): Builder = apply { useFrontCamera = enable }
+
+    /**
      * Build the BarcodeConfig required by the ScanBarcode ActivityResultContract.
      */
     public fun build(): ScannerConfig =
@@ -67,6 +74,7 @@ public class ScannerConfig internal constructor(
         hapticSuccessFeedback,
         showTorchToggle,
         horizontalFrameRatio,
+        useFrontCamera,
       )
   }
 

--- a/quickie/src/main/kotlin/io/github/g00fy2/quickie/extensions/ScannerConfigExtensions.kt
+++ b/quickie/src/main/kotlin/io/github/g00fy2/quickie/extensions/ScannerConfigExtensions.kt
@@ -11,4 +11,5 @@ internal fun ScannerConfig.toParcelableConfig() =
     hapticFeedback = hapticFeedback,
     showTorchToggle = showTorchToggle,
     horizontalFrameRatio = horizontalFrameRatio,
+    useFrontCamera = useFrontCamera,
   )

--- a/sample/src/main/kotlin/io/github/g00fy2/quickiesample/MainActivity.kt
+++ b/sample/src/main/kotlin/io/github/g00fy2/quickiesample/MainActivity.kt
@@ -47,6 +47,7 @@ class MainActivity : AppCompatActivity() {
           setHapticSuccessFeedback(false) // enable (default) or disable haptic feedback when a barcode was detected
           setShowTorchToggle(true) // show or hide (default) torch/flashlight toggle button
           setHorizontalFrameRatio(2.2f) // set the horizontal overlay ratio (default is 1 / square frame)
+          setUseFrontCamera(true) // use the front camera
         }
       )
     }


### PR DESCRIPTION
Here's the PR again on `develop`.

We are using Android devices as control pads for a device, the phone is mounted into the device itself so the back camera is not useable. The devices are enrolled into Azure IOT Central via a QR code.