### PR TITLE
Migrate away from AppCompat stuff

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,14 +2,14 @@
 quickie = "1.11.0"
 
 androidconfig-minSdk = "21"
-androidconfig-compileSdk = "35"
+androidconfig-compileSdk = "36"
 androidconfig-targetSdk = "35"
 androidconfig-buildTools = "36.0.0"
 
 androidGradle = "8.10.0"
 kotlin = "2.1.21"
 
-appcompat = "1.7.0"
+activity = "1.11.0"
 core = "1.16.0"
 
 cameraX = "1.4.2"
@@ -25,7 +25,7 @@ dokka = "2.0.0"
 junit = "5.12.2"
 
 [libraries]
-androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
+androidx-activity = { module = "androidx.activity:activity", version.ref = "activity" }
 androidx-camera = { module = "androidx.camera:camera-camera2", version.ref = "cameraX" }
 androidx-cameraLifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "cameraX" }
 androidx-cameraPreview = { module = "androidx.camera:camera-view", version.ref = "cameraX" }

--- a/quickie/build.gradle.kts
+++ b/quickie/build.gradle.kts
@@ -29,7 +29,7 @@ android {
 }
 
 dependencies {
-  implementation(libs.androidx.appcompat)
+  implementation(libs.androidx.activity)
   implementation(libs.androidx.core)
 
   implementation(libs.androidx.camera)

--- a/quickie/src/main/kotlin/io/github/g00fy2/quickie/QRScannerActivity.kt
+++ b/quickie/src/main/kotlin/io/github/g00fy2/quickie/QRScannerActivity.kt
@@ -11,9 +11,8 @@ import android.view.HapticFeedbackConstants
 import android.view.KeyEvent
 import android.view.View
 import android.view.WindowManager
+import androidx.activity.ComponentActivity
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.view.ContextThemeWrapper
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.Preview
@@ -34,7 +33,7 @@ import io.github.g00fy2.quickie.utils.MlKitErrorHandler
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
-internal class QRScannerActivity : AppCompatActivity() {
+internal class QRScannerActivity : ComponentActivity() {
 
   private lateinit var binding: QuickieScannerActivityBinding
   private lateinit var analysisExecutor: ExecutorService
@@ -60,10 +59,7 @@ internal class QRScannerActivity : AppCompatActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    val appThemeLayoutInflater = applicationInfo.theme.let { appThemeRes ->
-      if (appThemeRes != 0) layoutInflater.cloneInContext(ContextThemeWrapper(this, appThemeRes)) else layoutInflater
-    }
-    binding = QuickieScannerActivityBinding.inflate(appThemeLayoutInflater)
+    binding = QuickieScannerActivityBinding.inflate(layoutInflater)
     setContentView(binding.root)
 
     setupEdgeToEdgeUI()

--- a/quickie/src/main/res/values/themes.xml
+++ b/quickie/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <style name="QuickieScannerActivity" parent="Theme.AppCompat.DayNight.NoActionBar">
+  <style name="QuickieScannerActivity" parent="android:Theme.Material.Light.NoActionBar">
     <item name="android:statusBarColor">@color/quickie_transparent</item>
     <item name="android:navigationBarColor">@color/quickie_transparent</item>
   </style>

--- a/sample/src/main/kotlin/io/github/g00fy2/quickiesample/MainActivity.kt
+++ b/sample/src/main/kotlin/io/github/g00fy2/quickiesample/MainActivity.kt
@@ -5,7 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.widget.ArrayAdapter
 import android.widget.TextView
-import androidx.appcompat.app.AppCompatActivity
+import androidx.activity.ComponentActivity
 import androidx.core.net.toUri
 import com.google.android.material.snackbar.Snackbar
 import io.github.g00fy2.quickie.QRResult
@@ -20,7 +20,7 @@ import io.github.g00fy2.quickie.config.ScannerConfig
 import io.github.g00fy2.quickie.content.QRContent
 import io.github.g00fy2.quickiesample.databinding.ActivityMainBinding
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : ComponentActivity() {
 
   private lateinit var binding: ActivityMainBinding
   private var selectedBarcodeFormat = BarcodeFormat.FORMAT_ALL_FORMATS


### PR DESCRIPTION
Closes #295.

<details><summary>Diff details</summary>
<p>

```diff
 +--- com.google.mlkit:barcode-scanning:17.3.0
 |    +--- com.google.android.gms:play-services-basement:18.4.0
 |    |    +--- androidx.core:core:1.2.0 -> 1.16.0
 |    |    |    \--- androidx.lifecycle:lifecycle-runtime:2.6.2
-|    |    |         \--- androidx.profileinstaller:profileinstaller:1.3.0 -> 1.3.1
-|    |    |              +--- androidx.annotation:annotation:1.2.0 -> 1.8.1 (*)
-|    |    |              +--- androidx.concurrent:concurrent-futures:1.1.0 (*)
-|    |    |              +--- androidx.startup:startup-runtime:1.1.1
-|    |    |              |    +--- androidx.annotation:annotation:1.1.0 -> 1.8.1 (*)
-|    |    |              |    \--- androidx.tracing:tracing:1.0.0 -> 1.2.0
-|    |    |              |         +--- androidx.annotation:annotation:1.2.0 -> 1.8.1 (*)
-|    |    |              |         \--- androidx.tracing:tracing-ktx:1.2.0 (c)
-|    |    |              \--- com.google.guava:listenablefuture:1.0
+|    |    |         \--- androidx.profileinstaller:profileinstaller:1.3.0 -> 1.4.0
+|    |    |              +--- androidx.annotation:annotation:1.8.1 (*)
+|    |    |              +--- androidx.concurrent:concurrent-futures:1.1.0 (*)
+|    |    |              +--- androidx.startup:startup-runtime:1.1.1
+|    |    |              |    +--- androidx.annotation:annotation:1.1.0 -> 1.8.1 (*)
+|    |    |              |    \--- androidx.tracing:tracing:1.0.0 -> 1.2.0
+|    |    |              |         +--- androidx.annotation:annotation:1.2.0 -> 1.8.1 (*)
+|    |    |              |         \--- androidx.tracing:tracing-ktx:1.2.0 (c)
+|    |    |              \--- com.google.guava:listenablefuture:1.0
-|    |    \--- androidx.fragment:fragment:1.1.0 -> 1.5.4
-|    |         +--- androidx.activity:activity:1.5.1 -> 1.7.0
-|    |         |    +--- androidx.annotation:annotation:1.1.0 -> 1.8.1 (*)
-|    |         |    +--- androidx.collection:collection:1.0.0 -> 1.4.2 (*)
-|    |         |    +--- androidx.core:core:1.8.0 -> 1.16.0 (*)
-|    |         |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 -> 2.6.2 (*)
-|    |         |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 -> 2.6.2
-|    |         |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.8.1 (*)
-|    |         |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 -> 2.1.21 (*)
-|    |         |    |    +--- androidx.lifecycle:lifecycle-common:2.6.2 (c)
-|    |         |    |    +--- androidx.lifecycle:lifecycle-livedata:2.6.2 (c)
-|    |         |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.2 (c)
-|    |         |    |    +--- androidx.lifecycle:lifecycle-process:2.6.2 (c)
-|    |         |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.2 (c)
-|    |         |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.2 (c)
-|    |         |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 -> 2.6.2
-|    |         |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.8.1 (*)
-|    |         |    |    +--- androidx.core:core-ktx:1.2.0 -> 1.16.0
-|    |         |    |    |    +--- androidx.annotation:annotation:1.8.1 (*)
-|    |         |    |    |    +--- androidx.core:core:1.16.0 (*)
-|    |         |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib -> 2.1.21 (*)
-|    |         |    |    |    +--- androidx.core:core:1.16.0 (c)
-|    |         |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 2.1.21 (c)
-|    |         |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.2
-|    |         |    |    |    +--- androidx.arch.core:core-common:2.1.0 -> 2.2.0 (*)
-|    |         |    |    |    +--- androidx.arch.core:core-runtime:2.1.0 -> 2.2.0 (*)
-|    |         |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.2 (*)
-|    |         |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 -> 2.1.21 (*)
-|    |         |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.2 (c)
-|    |         |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.6.2 (c)
-|    |         |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.2 (c)
-|    |         |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.2 (c)
-|    |         |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.2 (c)
-|    |         |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.2 (c)
-|    |         |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.2 (*)
-|    |         |    |    +--- androidx.savedstate:savedstate:1.2.1
-|    |         |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.8.1 (*)
-|    |         |    |    |    +--- androidx.arch.core:core-common:2.1.0 -> 2.2.0 (*)
-|    |         |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 -> 2.6.2 (*)
-|    |         |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 -> 2.1.21 (*)
-|    |         |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 -> 2.1.21 (*)
-|    |         |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
-|    |         |    |    +--- androidx.lifecycle:lifecycle-common:2.6.2 (c)
-|    |         |    |    +--- androidx.lifecycle:lifecycle-livedata:2.6.2 (c)
-|    |         |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.2 (c)
-|    |         |    |    +--- androidx.lifecycle:lifecycle-process:2.6.2 (c)
-|    |         |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.2 (c)
-|    |         |    |    \--- androidx.lifecycle:lifecycle-viewmodel:2.6.2 (c)
-|    |         |    +--- androidx.profileinstaller:profileinstaller:1.3.0 -> 1.3.1 (*)
-|    |         |    +--- androidx.savedstate:savedstate:1.2.1 (*)
-|    |         |    +--- androidx.tracing:tracing:1.0.0 -> 1.2.0 (*)
-|    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 -> 2.1.21 (*)
-|    |         +--- androidx.annotation:annotation:1.1.0 -> 1.8.1 (*)
-|    |         +--- androidx.annotation:annotation-experimental:1.0.0 -> 1.4.1 (*)
-|    |         +--- androidx.collection:collection:1.1.0 -> 1.4.2 (*)
-|    |         +--- androidx.core:core-ktx:1.2.0 -> 1.16.0 (*)
-|    |         +--- androidx.lifecycle:lifecycle-livedata-core:2.5.1 -> 2.6.2 (*)
-|    |         +--- androidx.lifecycle:lifecycle-viewmodel:2.5.1 -> 2.6.2 (*)
-|    |         +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.5.1 -> 2.6.2 (*)
-|    |         +--- androidx.loader:loader:1.0.0
-|    |         |    +--- androidx.annotation:annotation:1.0.0 -> 1.8.1 (*)
-|    |         |    +--- androidx.core:core:1.0.0 -> 1.16.0 (*)
-|    |         |    +--- androidx.lifecycle:lifecycle-livedata:2.0.0 -> 2.6.2
-|    |         |    |    +--- androidx.arch.core:core-common:2.1.0 -> 2.2.0 (*)
-|    |         |    |    +--- androidx.arch.core:core-runtime:2.1.0 -> 2.2.0 (*)
-|    |         |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.2 (*)
-|    |         |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 -> 2.1.21 (*)
-|    |         |    |    +--- androidx.lifecycle:lifecycle-common:2.6.2 (c)
-|    |         |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.2 (c)
-|    |         |    |    +--- androidx.lifecycle:lifecycle-process:2.6.2 (c)
-|    |         |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.2 (c)
-|    |         |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.2 (c)
-|    |         |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.2 (c)
-|    |         |    \--- androidx.lifecycle:lifecycle-viewmodel:2.0.0 -> 2.6.2 (*)
-|    |         +--- androidx.savedstate:savedstate:1.2.0 -> 1.2.1 (*)
-|    |         +--- androidx.viewpager:viewpager:1.0.0
-|    |         |    +--- androidx.annotation:annotation:1.0.0 -> 1.8.1 (*)
-|    |         |    +--- androidx.core:core:1.0.0 -> 1.16.0 (*)
-|    |         |    \--- androidx.customview:customview:1.0.0
-|    |         |         +--- androidx.annotation:annotation:1.0.0 -> 1.8.1 (*)
-|    |         |         \--- androidx.core:core:1.0.0 -> 1.16.0 (*)
-|    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.6.21 -> 2.1.21 (*)
+|    |    \--- androidx.fragment:fragment:1.1.0 -> 1.3.6
+|    |         +--- androidx.annotation:annotation:1.1.0 -> 1.8.1 (*)
+|    |         +--- androidx.core:core:1.2.0 -> 1.16.0 (*)
+|    |         +--- androidx.collection:collection:1.1.0 -> 1.4.2 (*)
+|    |         +--- androidx.viewpager:viewpager:1.0.0
+|    |         |    +--- androidx.annotation:annotation:1.0.0 -> 1.8.1 (*)
+|    |         |    +--- androidx.core:core:1.0.0 -> 1.16.0 (*)
+|    |         |    \--- androidx.customview:customview:1.0.0
+|    |         |         +--- androidx.annotation:annotation:1.0.0 -> 1.8.1 (*)
+|    |         |         \--- androidx.core:core:1.0.0 -> 1.16.0 (*)
+|    |         +--- androidx.loader:loader:1.0.0
+|    |         |    +--- androidx.annotation:annotation:1.0.0 -> 1.8.1 (*)
+|    |         |    +--- androidx.core:core:1.0.0 -> 1.16.0 (*)
+|    |         |    +--- androidx.lifecycle:lifecycle-livedata:2.0.0 -> 2.6.2
+|    |         |    |    +--- androidx.arch.core:core-common:2.1.0 -> 2.2.0 (*)
+|    |         |    |    +--- androidx.arch.core:core-runtime:2.1.0 -> 2.2.0 (*)
+|    |         |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.2
+|    |         |    |    |    +--- androidx.arch.core:core-common:2.1.0 -> 2.2.0 (*)
+|    |         |    |    |    +--- androidx.arch.core:core-runtime:2.1.0 -> 2.2.0 (*)
+|    |         |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.2 (*)
+|    |         |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 -> 2.1.21 (*)
+|    |         |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.2 (c)
+|    |         |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.6.2 (c)
+|    |         |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.2 (c)
+|    |         |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.2 (c)
+|    |         |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.2 (c)
+|    |         |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.2 (c)
+|    |         |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 -> 2.1.21 (*)
+|    |         |    |    +--- androidx.lifecycle:lifecycle-common:2.6.2 (c)
+|    |         |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.2 (c)
+|    |         |    |    +--- androidx.lifecycle:lifecycle-process:2.6.2 (c)
+|    |         |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.2 (c)
+|    |         |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.2 (c)
+|    |         |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.2 (c)
+|    |         |    \--- androidx.lifecycle:lifecycle-viewmodel:2.0.0 -> 2.6.2
+|    |         |         +--- androidx.annotation:annotation:1.1.0 -> 1.8.1 (*)
+|    |         |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 -> 2.1.21 (*)
+|    |         |         +--- androidx.lifecycle:lifecycle-common:2.6.2 (c)
+|    |         |         +--- androidx.lifecycle:lifecycle-livedata:2.6.2 (c)
+|    |         |         +--- androidx.lifecycle:lifecycle-livedata-core:2.6.2 (c)
+|    |         |         +--- androidx.lifecycle:lifecycle-process:2.6.2 (c)
+|    |         |         +--- androidx.lifecycle:lifecycle-runtime:2.6.2 (c)
+|    |         |         \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.2 (c)
+|    |         +--- androidx.activity:activity:1.2.4 -> 1.11.0
+|    |         |    +--- androidx.annotation:annotation:1.8.1 (*)
+|    |         |    +--- androidx.core:core-ktx:1.13.0 -> 1.16.0
+|    |         |    |    +--- androidx.annotation:annotation:1.8.1 (*)
+|    |         |    |    +--- androidx.core:core:1.16.0 (*)
+|    |         |    |    +--- org.jetbrains.kotlin:kotlin-stdlib -> 2.1.21 (*)
+|    |         |    |    +--- androidx.core:core:1.16.0 (c)
+|    |         |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 2.1.21 (c)
+|    |         |    +--- androidx.core:core-viewtree:1.0.0 (*)
+|    |         |    +--- androidx.lifecycle:lifecycle-common:2.6.1 -> 2.6.2 (*)
+|    |         |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 -> 2.6.2 (*)
+|    |         |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 -> 2.6.2 (*)
+|    |         |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 -> 2.6.2
+|    |         |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.8.1 (*)
+|    |         |    |    +--- androidx.core:core-ktx:1.2.0 -> 1.16.0 (*)
+|    |         |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.2 (*)
+|    |         |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.2 (*)
+|    |         |    |    +--- androidx.savedstate:savedstate:1.2.1
+|    |         |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.8.1 (*)
+|    |         |    |    |    +--- androidx.arch.core:core-common:2.1.0 -> 2.2.0 (*)
+|    |         |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 -> 2.6.2 (*)
+|    |         |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 -> 2.1.21 (*)
+|    |         |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 -> 2.1.21 (*)
+|    |         |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 -> 1.7.3 (*)
+|    |         |    |    +--- androidx.lifecycle:lifecycle-common:2.6.2 (c)
+|    |         |    |    +--- androidx.lifecycle:lifecycle-livedata:2.6.2 (c)
+|    |         |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.2 (c)
+|    |         |    |    +--- androidx.lifecycle:lifecycle-process:2.6.2 (c)
+|    |         |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.2 (c)
+|    |         |    |    \--- androidx.lifecycle:lifecycle-viewmodel:2.6.2 (c)
+|    |         |    +--- androidx.profileinstaller:profileinstaller:1.4.0 (*)
+|    |         |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |         |    +--- androidx.tracing:tracing:1.0.0 -> 1.2.0 (*)
+|    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib -> 2.1.21 (*)
+|    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3 (*)
+|    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 -> 2.1.21 (c)
+|    |         +--- androidx.lifecycle:lifecycle-livedata-core:2.3.1 -> 2.6.2 (*)
+|    |         +--- androidx.lifecycle:lifecycle-viewmodel:2.3.1 -> 2.6.2 (*)
+|    |         +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.3.1 -> 2.6.2 (*)
+|    |         +--- androidx.savedstate:savedstate:1.1.0 -> 1.2.1 (*)
+|    |         \--- androidx.annotation:annotation-experimental:1.0.0 -> 1.4.1 (*)
 |    \--- com.google.android.gms:play-services-mlkit-barcode-scanning:18.3.1
 |         +--- com.google.android.gms:play-services-base:18.5.0
-|         |    \--- androidx.fragment:fragment:1.0.0 -> 1.5.4 (*)
+|         |    \--- androidx.fragment:fragment:1.0.0 -> 1.3.6 (*)
 |         \--- com.google.mlkit:barcode-scanning-common:17.0.0
 |              \--- com.google.mlkit:vision-common:17.0.0 -> 17.3.0
 |                   \--- com.google.mlkit:common:18.6.0 -> 18.11.0
-|                        \--- androidx.appcompat:appcompat:1.6.1 -> 1.7.0
-|                             +--- androidx.activity:activity:1.7.0 (*)
-|                             +--- androidx.annotation:annotation:1.3.0 -> 1.8.1 (*)
-|                             +--- androidx.appcompat:appcompat-resources:1.7.0
-|                             |    +--- androidx.annotation:annotation:1.2.0 -> 1.8.1 (*)
-|                             |    +--- androidx.collection:collection:1.0.0 -> 1.4.2 (*)
-|                             |    +--- androidx.core:core:1.6.0 -> 1.16.0 (*)
-|                             |    +--- androidx.vectordrawable:vectordrawable:1.1.0
-|                             |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.8.1 (*)
-|                             |    |    +--- androidx.core:core:1.1.0 -> 1.16.0 (*)
-|                             |    |    \--- androidx.collection:collection:1.1.0 -> 1.4.2 (*)
-|                             |    +--- androidx.vectordrawable:vectordrawable-animated:1.1.0
-|                             |    |    +--- androidx.vectordrawable:vectordrawable:1.1.0 (*)
-|                             |    |    +--- androidx.interpolator:interpolator:1.0.0 (*)
-|                             |    |    \--- androidx.collection:collection:1.1.0 -> 1.4.2 (*)
-|                             |    \--- androidx.appcompat:appcompat:1.7.0 (c)
-|                             +--- androidx.collection:collection:1.0.0 -> 1.4.2 (*)
-|                             +--- androidx.core:core:1.13.0 -> 1.16.0 (*)
-|                             +--- androidx.core:core-ktx:1.13.0 -> 1.16.0 (*)
-|                             +--- androidx.cursoradapter:cursoradapter:1.0.0
-|                             |    \--- androidx.annotation:annotation:1.0.0 -> 1.8.1 (*)
-|                             +--- androidx.drawerlayout:drawerlayout:1.0.0
-|                             |    +--- androidx.annotation:annotation:1.0.0 -> 1.8.1 (*)
-|                             |    +--- androidx.core:core:1.0.0 -> 1.16.0 (*)
-|                             |    \--- androidx.customview:customview:1.0.0 (*)
-|                             +--- androidx.emoji2:emoji2:1.3.0
-|                             |    +--- androidx.annotation:annotation:1.2.0 -> 1.8.1 (*)
-|                             |    +--- androidx.collection:collection:1.1.0 -> 1.4.2 (*)
-|                             |    +--- androidx.core:core:1.3.0 -> 1.16.0 (*)
-|                             |    +--- androidx.lifecycle:lifecycle-process:2.4.1 -> 2.6.2
-|                             |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.8.1 (*)
-|                             |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.2 (*)
-|                             |    |    +--- androidx.startup:startup-runtime:1.1.1 (*)
-|                             |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 -> 2.1.21 (*)
-|                             |    |    +--- androidx.lifecycle:lifecycle-common:2.6.2 (c)
-|                             |    |    +--- androidx.lifecycle:lifecycle-livedata:2.6.2 (c)
-|                             |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.2 (c)
-|                             |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.2 (c)
-|                             |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.2 (c)
-|                             |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.2 (c)
-|                             |    +--- androidx.startup:startup-runtime:1.0.0 -> 1.1.1 (*)
-|                             |    \--- androidx.emoji2:emoji2-views-helper:1.3.0 (c)
-|                             +--- androidx.emoji2:emoji2-views-helper:1.2.0 -> 1.3.0
-|                             |    +--- androidx.collection:collection:1.1.0 -> 1.4.2 (*)
-|                             |    +--- androidx.core:core:1.3.0 -> 1.16.0 (*)
-|                             |    +--- androidx.emoji2:emoji2:1.3.0 (*)
-|                             |    \--- androidx.emoji2:emoji2:1.3.0 (c)
-|                             +--- androidx.fragment:fragment:1.5.4 (*)
-|                             +--- androidx.lifecycle:lifecycle-runtime:2.6.1 -> 2.6.2 (*)
-|                             +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 -> 2.6.2 (*)
-|                             +--- androidx.profileinstaller:profileinstaller:1.3.1 (*)
-|                             +--- androidx.resourceinspection:resourceinspection-annotation:1.0.1
-|                             |    \--- androidx.annotation:annotation:1.1.0 -> 1.8.1 (*)
-|                             +--- androidx.savedstate:savedstate:1.2.1 (*)
-|                             +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.22 -> 2.1.21 (*)
-|                             \--- androidx.appcompat:appcompat-resources:1.7.0 (c)
+|                        \--- androidx.appcompat:appcompat:1.6.1
+|                             +--- androidx.activity:activity:1.6.0 -> 1.11.0 (*)
+|                             +--- androidx.annotation:annotation:1.3.0 -> 1.8.1 (*)
+|                             +--- androidx.appcompat:appcompat-resources:1.6.1
+|                             |    +--- androidx.annotation:annotation:1.2.0 -> 1.8.1 (*)
+|                             |    +--- androidx.collection:collection:1.0.0 -> 1.4.2 (*)
+|                             |    +--- androidx.core:core:1.6.0 -> 1.16.0 (*)
+|                             |    +--- androidx.vectordrawable:vectordrawable:1.1.0
+|                             |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.8.1 (*)
+|                             |    |    +--- androidx.core:core:1.1.0 -> 1.16.0 (*)
+|                             |    |    \--- androidx.collection:collection:1.1.0 -> 1.4.2 (*)
+|                             |    +--- androidx.vectordrawable:vectordrawable-animated:1.1.0
+|                             |    |    +--- androidx.vectordrawable:vectordrawable:1.1.0 (*)
+|                             |    |    +--- androidx.interpolator:interpolator:1.0.0 (*)
+|                             |    |    \--- androidx.collection:collection:1.1.0 -> 1.4.2 (*)
+|                             |    \--- androidx.appcompat:appcompat:1.6.1 (c)
+|                             +--- androidx.collection:collection:1.0.0 -> 1.4.2 (*)
+|                             +--- androidx.core:core:1.9.0 -> 1.16.0 (*)
+|                             +--- androidx.core:core-ktx:1.8.0 -> 1.16.0 (*)
+|                             +--- androidx.cursoradapter:cursoradapter:1.0.0
+|                             |    \--- androidx.annotation:annotation:1.0.0 -> 1.8.1 (*)
+|                             +--- androidx.drawerlayout:drawerlayout:1.0.0
+|                             |    +--- androidx.annotation:annotation:1.0.0 -> 1.8.1 (*)
+|                             |    +--- androidx.core:core:1.0.0 -> 1.16.0 (*)
+|                             |    \--- androidx.customview:customview:1.0.0 (*)
+|                             +--- androidx.emoji2:emoji2:1.2.0
+|                             |    +--- androidx.annotation:annotation:1.2.0 -> 1.8.1 (*)
+|                             |    +--- androidx.collection:collection:1.1.0 -> 1.4.2 (*)
+|                             |    +--- androidx.core:core:1.3.0 -> 1.16.0 (*)
+|                             |    +--- androidx.lifecycle:lifecycle-process:2.4.1 -> 2.6.2
+|                             |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.8.1 (*)
+|                             |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.2 (*)
+|                             |    |    +--- androidx.startup:startup-runtime:1.1.1 (*)
+|                             |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 -> 2.1.21 (*)
+|                             |    |    +--- androidx.lifecycle:lifecycle-common:2.6.2 (c)
+|                             |    |    +--- androidx.lifecycle:lifecycle-livedata:2.6.2 (c)
+|                             |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.2 (c)
+|                             |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.2 (c)
+|                             |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.2 (c)
+|                             |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.2 (c)
+|                             |    \--- androidx.startup:startup-runtime:1.0.0 -> 1.1.1 (*)
+|                             +--- androidx.emoji2:emoji2-views-helper:1.2.0
+|                             |    +--- androidx.collection:collection:1.1.0 -> 1.4.2 (*)
+|                             |    +--- androidx.core:core:1.3.0 -> 1.16.0 (*)
+|                             |    \--- androidx.emoji2:emoji2:1.2.0 (*)
+|                             +--- androidx.fragment:fragment:1.3.6 (*)
+|                             +--- androidx.lifecycle:lifecycle-runtime:2.5.1 -> 2.6.2 (*)
+|                             +--- androidx.lifecycle:lifecycle-viewmodel:2.5.1 -> 2.6.2 (*)
+|                             +--- androidx.resourceinspection:resourceinspection-annotation:1.0.1
+|                             |    \--- androidx.annotation:annotation:1.1.0 -> 1.8.1 (*)
+|                             +--- androidx.savedstate:savedstate:1.2.0 -> 1.2.1 (*)
+|                             +--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 2.1.21 (*)
+|                             \--- androidx.appcompat:appcompat-resources:1.6.1 (c)
++--- androidx.activity:activity:1.11.0 (*)
-+--- androidx.appcompat:appcompat:1.7.0 (*)
 \--- androidx.camera:camera-view:1.4.2
-     \--- androidx.appcompat:appcompat:1.1.0 -> 1.7.0 (*)
+     \--- androidx.appcompat:appcompat:1.1.0 -> 1.6.1 (*)
```

</p>
</details> 