### PR TITLE
Add display value to QRContent and update Intent handling

### DIFF
--- a/quickie/src/main/kotlin/io/github/g00fy2/quickie/QRScannerActivity.kt
+++ b/quickie/src/main/kotlin/io/github/g00fy2/quickie/QRScannerActivity.kt
@@ -165,6 +165,7 @@ internal class QRScannerActivity : AppCompatActivity() {
       Intent().apply {
         putExtra(EXTRA_RESULT_BYTES, result.rawBytes)
         putExtra(EXTRA_RESULT_VALUE, result.rawValue)
+        putExtra(EXTRA_RESULT_DISPLAY_VALUE, result.displayValue)
         putExtra(EXTRA_RESULT_TYPE, result.valueType)
         putExtra(EXTRA_RESULT_PARCELABLE, result.toParcelableContentType())
       }
@@ -216,6 +217,7 @@ internal class QRScannerActivity : AppCompatActivity() {
     const val EXTRA_CONFIG = "quickie-config"
     const val EXTRA_RESULT_BYTES = "quickie-bytes"
     const val EXTRA_RESULT_VALUE = "quickie-value"
+    const val EXTRA_RESULT_DISPLAY_VALUE = "quickie-display-value"
     const val EXTRA_RESULT_TYPE = "quickie-type"
     const val EXTRA_RESULT_PARCELABLE = "quickie-parcelable"
     const val EXTRA_RESULT_EXCEPTION = "quickie-exception"

--- a/quickie/src/main/kotlin/io/github/g00fy2/quickie/content/QRContent.kt
+++ b/quickie/src/main/kotlin/io/github/g00fy2/quickie/content/QRContent.kt
@@ -3,7 +3,7 @@ package io.github.g00fy2.quickie.content
 @Suppress("ArrayInDataClass")
 public sealed class QRContent(
   public open val rawBytes: ByteArray?,
-  public open val rawValue: String?,
+  public open val rawValue: String?
 ) {
 
   /**
@@ -11,7 +11,8 @@ public sealed class QRContent(
    */
   public data class Plain(
     override val rawBytes: ByteArray?,
-    override val rawValue: String?
+    override val rawValue: String?,
+    val displayValue: String?
   ) : QRContent(rawBytes, rawValue)
 
   /**

--- a/quickie/src/main/kotlin/io/github/g00fy2/quickie/content/QRContent.kt
+++ b/quickie/src/main/kotlin/io/github/g00fy2/quickie/content/QRContent.kt
@@ -3,7 +3,7 @@ package io.github.g00fy2.quickie.content
 @Suppress("ArrayInDataClass")
 public sealed class QRContent(
   public open val rawBytes: ByteArray?,
-  public open val rawValue: String?
+  public open val rawValue: String?,
 ) {
 
   /**
@@ -12,7 +12,7 @@ public sealed class QRContent(
   public data class Plain(
     override val rawBytes: ByteArray?,
     override val rawValue: String?,
-    val displayValue: String?
+    val displayValue: String?,
   ) : QRContent(rawBytes, rawValue)
 
   /**

--- a/quickie/src/main/kotlin/io/github/g00fy2/quickie/extensions/IntentExtensions.kt
+++ b/quickie/src/main/kotlin/io/github/g00fy2/quickie/extensions/IntentExtensions.kt
@@ -39,7 +39,8 @@ import io.github.g00fy2.quickie.content.WifiParcelable
 internal fun Intent?.toQuickieContentType(): QRContent {
   val rawBytes = this?.getByteArrayExtra(EXTRA_RESULT_BYTES)
   val rawValue = this?.getStringExtra(EXTRA_RESULT_VALUE)
-  return this?.toQuickieContentType(rawBytes, rawValue) ?: Plain(rawBytes, rawValue)
+  val displayValue = this?.getStringExtra(QRScannerActivity.EXTRA_RESULT_DISPLAY_VALUE)
+  return this?.toQuickieContentType(rawBytes, rawValue) ?: Plain(rawBytes, rawValue, displayValue)
 }
 
 @Suppress("LongMethod")

--- a/sample/src/main/kotlin/io/github/g00fy2/quickiesample/MainActivity.kt
+++ b/sample/src/main/kotlin/io/github/g00fy2/quickiesample/MainActivity.kt
@@ -60,9 +60,11 @@ class MainActivity : AppCompatActivity() {
   private fun showSnackbar(result: QRResult) {
     val text = when (result) {
       is QRSuccess -> {
-        result.content.rawValue
-        // decoding with default UTF-8 charset when rawValue is null will not result in meaningful output, demo purpose
-          ?: result.content.rawBytes?.let { String(it) }.orEmpty()
+        val displayValue = (result.content as? QRContent.Plain)
+          ?.displayValue
+          ?.takeIf { it.isNotBlank() }
+        displayValue?.let { "$it\n" }.orEmpty() +
+          (result.content.rawValue ?: result.content.rawBytes?.let(::String).orEmpty())
       }
       QRUserCanceled -> "User canceled"
       QRMissingPermission -> "Missing permission"

--- a/sample/src/main/kotlin/io/github/g00fy2/quickiesample/MainActivity.kt
+++ b/sample/src/main/kotlin/io/github/g00fy2/quickiesample/MainActivity.kt
@@ -60,11 +60,9 @@ class MainActivity : AppCompatActivity() {
   private fun showSnackbar(result: QRResult) {
     val text = when (result) {
       is QRSuccess -> {
-        val displayValue = (result.content as? QRContent.Plain)
-          ?.displayValue
-          ?.takeIf { it.isNotBlank() }
-        displayValue?.let { "$it\n" }.orEmpty() +
-          (result.content.rawValue ?: result.content.rawBytes?.let(::String).orEmpty())
+        result.content.rawValue
+        // decoding with default UTF-8 charset when rawValue is null will not result in meaningful output, demo purpose
+          ?: result.content.rawBytes?.let { String(it) }.orEmpty()
       }
       QRUserCanceled -> "User canceled"
       QRMissingPermission -> "Missing permission"


### PR DESCRIPTION
Hi, good morning !

When read a Barcode, the rawValue contain the type of barcode plus the value, this type of barcode is in the start of the String, for example: ]C1905792899782181343793999265500012900 and the correct value is 905792899782181343793999265500012900.

I add new String extra, named "EXTRA_RESULT_DISPLAY_VALUE", to send this new value without barcode type("]C1").

Kind regards